### PR TITLE
On Julia 1.0 the ip prefix doesn't seem to work

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ endpoints = [
 s = Joseki.server(endpoints)
 
 # Fire up the server
-HTTP.serve(s, ip"127.0.0.1", 8000; verbose=false)
+HTTP.serve(s, "127.0.0.1", 8000; verbose=false)
 ```
 
 If you run this example you can try it out by going to http://localhost:8000/pow/?x=2&y=3.  You should see a response like:


### PR DESCRIPTION
This small changed worked for me on Julia 1.0