### PR TITLE
New syntax for regex replace in Julia 1.0

### DIFF
--- a/src/responders.jl
+++ b/src/responders.jl
@@ -46,7 +46,7 @@ function error_responder(req::HTTP.Request, e::String)
     
     # Make sure we don't have unescaped quotes in the error string since
     # we are going to return it as a json
-    ee = replace(e, r"(?<!\\)(?:\\{2})*\K\"", "\\\"")
+    ee = replace(e, r"(?<!\\)(?:\\{2})*\K\"" => "\\\"")
     b = """{"error": true, "message": "$(ee)"}"""
     req.response.body = bytes(b)
     return req.response


### PR DESCRIPTION
The syntax for string `replace` with regular expressions seem to have changes from
https://docs.julialang.org/en/v0.6.1/manual/strings/#Regular-Expressions-1
to
https://docs.julialang.org/en/v1/manual/strings/#Regular-Expressions-1

This code commit makes that change.