### PR TITLE
Casting to String destroys the original Array of UInts.

### DIFF
--- a/src/middleware.jl
+++ b/src/middleware.jl
@@ -34,7 +34,7 @@ end
 Log the request body.
 """
 function body_logger!(req::HTTP.Request)
-    println(String(req.body))
+    println(String(copy(req.body)))
     return req
 end
 


### PR DESCRIPTION
As soon as we cast an `Array{UInt8,1}`, the array becomes empty.

This prevents the `HTTP.Request.body` from being used in the endpoints.

This change uses a copy of the `body` for the logger, leaving the original `body` intact.

I found more info here:
https://thenewphalls.wordpress.com/2014/04/07/julia-variable-gotchas/