### PR TITLE
Make README copy-paste-able by also using HTTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You combine a set of middleware, endpoints, and optionally an error-handling fun
 To install Joseki.jl, run `Pkg.clone("https://github.com/amellnik/Joseki.jl.git")`.
 
 ```julia
-using Joseki, JSON
+using Joseki, JSON, HTTP
 
 ### Create some endpoints
 


### PR DESCRIPTION
Hi, I don't know if it matters much to you, but adding `using HTTP` to the example in the README will make it a bit more complete.