### PR TITLE
Enable tagbot

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,0 +1,16 @@
+name: TagBot
+on:
+  issue_comment:
+    types:
+      - created
+  workflow_dispatch:
+jobs:
+  TagBot:
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: JuliaRegistries/TagBot@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ssh: ${{ secrets.FOR_TAGBOT }}
+          ssh_password: ${{ secrets.FOR_TAGBOT_SECRET }}


### PR DESCRIPTION
Apparently this will make the process of tagging new releases less painful, following the instructions at https://github.com/marketplace/actions/julia-tagbot#ssh-deploy-keys